### PR TITLE
Add basic mod settings & bump version to 1.3.14

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -21,17 +21,19 @@ data.raw["assembling-machine"]["eaf-mk04"].energy_usage = "120MW"
 RECIPE("yaedols-spores-to-oxygen"):add_unlock("yaedols-upgrade")
 RECIPE("bonemeal-to-geothermal-water"):add_unlock("ulric-upgrade")
 
-for _, chest_type in pairs {"basic", "active-provider", "passive-provider", "buffer", "storage", "requester"} do
-    local container_type = chest_type == "basic" and "container" or "logistic-container"
-    local steel = chest_type == "basic" and "steel-chest" or (chest_type .. "-chest")
-    data.raw[container_type][steel].inventory_size = 20
-    data.raw[container_type]["py-shed-" .. chest_type].inventory_size = 40
-    data.raw[container_type]["py-storehouse-" .. chest_type].inventory_size = 80
-    data.raw[container_type]["py-warehouse-" .. chest_type].inventory_size = 120
-    data.raw[container_type]["py-deposit-" .. chest_type].inventory_size = 160
+if settings.startup["pyhm-decrease-containers-inventory-size"].value then
+    for _, chest_type in pairs {"basic", "active-provider", "passive-provider", "buffer", "storage", "requester"} do
+        local container_type = chest_type == "basic" and "container" or "logistic-container"
+        local steel = chest_type == "basic" and "steel-chest" or (chest_type .. "-chest")
+        data.raw[container_type][steel].inventory_size = 20
+        data.raw[container_type]["py-shed-" .. chest_type].inventory_size = 40
+        data.raw[container_type]["py-storehouse-" .. chest_type].inventory_size = 80
+        data.raw[container_type]["py-warehouse-" .. chest_type].inventory_size = 120
+        data.raw[container_type]["py-deposit-" .. chest_type].inventory_size = 160
+    end
+    data.raw.container["wooden-chest"].inventory_size = 4
+    data.raw.container["iron-chest"].inventory_size = 8
 end
-data.raw.container["wooden-chest"].inventory_size = 4
-data.raw.container["iron-chest"].inventory_size = 8
 
 RECIPE("neutron-absorber-mk01"):remove_unlock("nuclear-power"):add_unlock("uranium-processing")
 

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -5,20 +5,20 @@ pyhardmode=Pyanodons Hard Mode
 pyhardmode=Contains a few tiny changes to Pyanodons mods...
 
 [entity-name]
-py-sinkhole=Outfall
 py-gas-vent=Exhaust pipe
 nuclear-reactor=Breeder reactor
 electric-furnace=Electric furnace
+pyhm-outfall=Outfall
 
 [entity-description]
-py-sinkhole=Send those fluids back to where they came. Must be placed on water.
-py-gas-vent=Dispose unwanted gases into the atmosphere.
 nuclear-reactor=Generates waste heat that must be removed.
+py-gas-vent=Dispose unwanted gases into the atmosphere.
 py-burner=Burns logs, trees, and biomass into heat.
 py-coal-powerplant-mk01=Advanced plant to convert the good ol' coal into heat.
 py-coal-powerplant-mk02=Advanced plant to convert the good ol' coal into heat.
 py-coal-powerplant-mk03=Advanced plant to convert the good ol' coal into heat.
 py-coal-powerplant-mk04=Advanced plant to convert the good ol' coal into heat.
+pyhm-outfall=Send those fluids back to where they came. Must be placed on water.
 rtg=Great use of isotopes to generate huge heat. 
 max-temperature=[font=default-semibold][color=255,230,192]Max. temperature: [/color][/font]__1__°C.
 
@@ -46,3 +46,14 @@ sweater=Sweater
 [technology-description]
 py-burner=Technologies for the transfer of heat over distance. Heat pipes have a decay of 2°C per tile. You cannot lose energy. This only effects the max length heat can travel.
 simik-mk01=Exotic animals that are adapted for life in extreme temperatures.
+
+[mod-setting-name]
+pyhm-decrease-containers-inventory-size=Decrease containers' inventory size
+pyhm-replace-sinkhole-with-outfall=Replace __ENTITY__py-sinkhole__ with __ENTITY__pyhm-outfall__
+pyhm-resource-rocks-disallow-building-over=Disallow building non-miner structures over resource rocks
+pyhm-resource-rocks-infinite=Infinite resource rocks
+
+[mod-setting-description]
+pyhm-decrease-containers-inventory-size=Decreases regular and logistic containers' inventory size.\n[entity=wooden-chest]: 16 -> 4\n[entity=iron-chest]: 32 -> 8\n[entity=steel-chest]: 48 -> 20\n[entity=py-shed-basic]: 75 -> 40\n[entity=py-storehouse-basic]: 150 -> 80\n[entity=py-warehouse-basic]: 450 -> 120\n[entity=py-deposit-basic]: 800 -> 160
+pyhm-replace-sinkhole-with-outfall=Changes __ENTITY__py-sinkhole__ to __ENTITY__pyhm-outfall__. __ENTITY__pyhm-outfall__ needs to be placed over the water.
+pyhm-resource-rocks-disallow-building-over=With this option enabled you won't be able to build structures other than mines over resource rocks.\n\n"You shall not build belts nor rails over boulders".

--- a/prototypes/mining.lua
+++ b/prototypes/mining.lua
@@ -24,30 +24,38 @@ local resource_rocks = {
     "volcanic-pipe"
 }
 
+local setting_resource_rocks_disallow_building_over = settings.startup["pyhm-resource-rocks-disallow-building-over"].value
+
 local categories = {}
 for _, resource in pairs(resource_rocks) do
     resource = data.raw.resource[resource]
-    local mask = collision_mask_util.get_mask(resource)
-    mask.layers["object"] = true
-    resource.collision_mask = mask
-    categories[resource.category] = true
-    resource.infinite = true
-    resource.infinite_depletion_amount = 0
-    resource.normal = 10
-    resource.minimum = resource.normal
-    if resource.autoplace then
-        resource.autoplace.richness_expression = "10"
+    if setting_resource_rocks_disallow_building_over then
+        local mask = collision_mask_util.get_mask(resource)
+        mask.layers["object"] = true
+        resource.collision_mask = mask
+        categories[resource.category] = true
+    end
+    if settings.startup["pyhm-resource-rocks-infinite"].value then
+        resource.infinite = true
+        resource.infinite_depletion_amount = 0
+        resource.normal = 10
+        resource.minimum = resource.normal
+        if resource.autoplace then
+            resource.autoplace.richness_expression = "10"
+        end
     end
 end
 
-for _, miner in pairs(data.raw["mining-drill"]) do
-    if miner.resource_categories then
-        for _, category in pairs(miner.resource_categories) do
-            if categories[category] then
-                local mask = collision_mask_util.get_mask(miner)
-                mask.layers["object"] = nil
-                miner.collision_mask = mask
-                break
+if setting_resource_rocks_disallow_building_over then
+    for _, miner in pairs(data.raw["mining-drill"]) do
+        if miner.resource_categories then
+            for _, category in pairs(miner.resource_categories) do
+                if categories[category] then
+                    local mask = collision_mask_util.get_mask(miner)
+                    mask.layers["object"] = nil
+                    miner.collision_mask = mask
+                    break
+                end
             end
         end
     end

--- a/prototypes/void-machines.lua
+++ b/prototypes/void-machines.lua
@@ -11,8 +11,13 @@ for _, void_machine in pairs {"py-sinkhole", "py-gas-vent"} do
 end
 
 data.raw["assembling-machine"]["py-gas-vent"].crafting_speed = 5
+
 data.raw["assembling-machine"]["py-sinkhole"].fixed_recipe = "water-pyvoid-fluid"
-data.raw["assembling-machine"]["py-sinkhole"].collision_mask = {layers = {ground_tile = true, object = true}}
+if settings.startup["pyhm-replace-sinkhole-with-outfall"].value then
+    data.raw["assembling-machine"]["py-sinkhole"].collision_mask = {layers = {ground_tile = true, object = true}}
+    data.raw["assembling-machine"]["py-sinkhole"].localised_description = { "entity-description.pyhm-outfall" }
+    data.raw["assembling-machine"]["py-sinkhole"].localised_name = { "entity-name.pyhm-outfall" }
+end
 
 RECIPE("py-gas-vent"):remove_unlock("coal-processing-1")
 RECIPE("py-gas-vent"):add_unlock("filtration")

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,26 @@
+data:extend({
+    {
+        type = "bool-setting",
+        name = "pyhm-decrease-containers-inventory-size",
+        default_value = true,
+        setting_type = "startup"
+    },
+    {
+        type = "bool-setting",
+        name = "pyhm-replace-sinkhole-with-outfall",
+        default_value = true,
+        setting_type = "startup"
+    },
+    {
+        type = "bool-setting",
+        name = "pyhm-resource-rocks-disallow-building-over",
+        default_value = true,
+        setting_type = "startup"
+    },
+    {
+        type = "bool-setting",
+        name = "pyhm-resource-rocks-infinite",
+        default_value = true,
+        setting_type = "startup"
+    }
+})


### PR DESCRIPTION
[As discussed on Discord](https://discord.com/channels/560199483065892894/1216966663338196993/1313683658921738240), I've added couple of basic settings covering ability to toggle the following settings:
- decrease of containers' inventory size,
- disallow building other entities than mines on resource rocks,
- outfall placement rules with conditional change of its name depending on the setting's value,
- making resource rocks infinite.

Feel free to adjust anything to your liking before merging it.

![image](https://github.com/user-attachments/assets/8fd5bfe5-f3a1-49a9-b932-76b3f05da291)
![image](https://github.com/user-attachments/assets/2a4d7381-0294-4325-8d24-79ac04368ba4)
![image](https://github.com/user-attachments/assets/29461a20-72d9-4ed3-bda3-f78080f497ab)