### PR TITLE
Change EN locale when fluid mining is not yet researched

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -57,3 +57,6 @@ pyhm-resource-rocks-infinite=Infinite resource rocks
 pyhm-decrease-containers-inventory-size=Decreases regular and logistic containers' inventory size.\n[entity=wooden-chest]: 16 -> 4\n[entity=iron-chest]: 32 -> 8\n[entity=steel-chest]: 48 -> 20\n[entity=py-shed-basic]: 75 -> 40\n[entity=py-storehouse-basic]: 150 -> 80\n[entity=py-warehouse-basic]: 450 -> 120\n[entity=py-deposit-basic]: 800 -> 160
 pyhm-replace-sinkhole-with-outfall=Changes __ENTITY__py-sinkhole__ to __ENTITY__pyhm-outfall__. __ENTITY__pyhm-outfall__ needs to be placed over the water.
 pyhm-resource-rocks-disallow-building-over=With this option enabled you won't be able to build structures other than mines over resource rocks.\n\n"You shall not build belts nor rails over boulders".
+
+[cant-build-reason]
+mining-with-fluid-not-available=Usage of fluid in mining drills not researched.


### PR DESCRIPTION
Factorio defaults to a message that says "Uranium mining not researched" when trying to place a drill on any ore that requires fluids. This is obviously not correct for Py Hard Mode.

This updates the message to reference "Usage of fluid in mining drills", which is the unlock shown in the "Steam power" tech unlocked by producing iron plates.