### PR TITLE
Migrate dirty-water-light to muddy-sludge

### DIFF
--- a/prototypes/recycling-recipes.lua
+++ b/prototypes/recycling-recipes.lua
@@ -8,7 +8,7 @@ if mods.PyBlock then
         enabled = true,
         energy_required = 4,
         ingredients = {
-            {type = "fluid", name = "dirty-water-light", amount = 100},
+            {type = "fluid", name = "muddy-sludge", amount = 100},
         },
         results = {
             {type = "fluid", name = "water", amount = 100},
@@ -24,7 +24,7 @@ else
         enabled = false,
         energy_required = 3,
         ingredients = {
-            {type = "fluid", name = "dirty-water-light", amount = 100},
+            {type = "fluid", name = "muddy-sludge", amount = 100},
         },
         results = {
             {type = "fluid", name = "water",  amount = 100},


### PR DESCRIPTION
The fix to support latest changes in the Py, it is similar to: https://github.com/pyanodon/PyBlock/commit/900d82eb50773bb0e5c8392f72dec79d6f2156b1
This will prevent the next error:
>Error in assignID: fluid with name 'dirty-water-light' does not exist.