### PR TITLE
Restore comfy sweater's teleport functionality

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -88,17 +88,23 @@ script.on_event(defines.events.on_entity_died, function(event)
     inventory.clear()
 end)
 
---[[
 -- teleport player to cursor position when they are in map view & wearing a sweater
 local armor_inventory = defines.inventory.character_armor
 local render_mode = defines.render_mode.game
+local controller_type = defines.controllers.character
 script.on_event("open-gui", function(event)
     local player = game.get_player(event.player_index)
-    if player.render_mode == render_mode then return end
-    local armor = player.get_inventory(armor_inventory)
+    if player.render_mode == render_mode then return end -- don't teleport in game view
+    if event.selected_prototype then return end -- don't teleport when opening things remotely
+    if player.physical_controller_type ~= controller_type then return end -- don't teleport players who don't have bodies
+
+    local character = player.character
+    if not character or not character.valid then return end
+    local armor = character.get_inventory(armor_inventory)
     if not armor then return end
+
     local armor_slot = armor[1]
     if armor_slot.valid_for_read and armor_slot.name == "sweater" then
-        player.teleport(event.cursor_position)
+        character.teleport(event.cursor_position)
     end
-end)--]]
+end)

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -29,7 +29,7 @@ sweater=Sweater
 
 [item-description]
 macguffin=Caution! Realism alert! You are overthinking again, please remain calm and enjoy the game.
-sweater=It's a sweater. It's warm and cozy. It's also a bit itchy. Become immune to all damage.
+sweater=It's a sweater. It's warm and cozy. It's also a bit itchy. Click anywhere on the map to teleport. Become immune to all damage.
 
 [pywiki-descriptions]
 beacon=The [entity=beacon-AM1-FM1] and [entity=diet-beacon-AM1-FM1] use radio signals to trasmit module effects into nearby assembling machines. Each beacon has both an AM and an FM frequency that determines the effect radius, transmission efficiency, and power usage.\nThe AM and FM frequency sliders range from 1-5.\n\n[entity=diet-beacon-AM1-FM1]\nEffect radius:\n    - AM1: 32\n    - AM2: 24\n    - AM3: 16\n    - AM4: 8\n    - AM5: 2\nTransmission efficiency: 0.1 * AM * FM\nPower consumption: AM * (FM ^ 3) / 2 MW\n\n[entity=beacon-AM1-FM1]\nEffect radius:\n    - AM1: 64\n    - AM2: 48\n    - AM3: 32\n    - AM4: 16\n    - AM5: 2\nTransmission efficiency: 0.2 * AM * FM\nPower consumption: AM * (FM ^ 3) MW\n\nThe default 1AM 1FM beacon is wide area low power.\nIf two beacons have the same AM:FM frequencies, the signals will interfere and cancel each other out.\nBeacons do not accept productivity modules such as [item=productivity-module-3].


### PR DESCRIPTION
Checks for a selected prototype so opening things in remote view *shouldn't* put you inside buildings (or worse, trains).