### PR TITLE
2.1 Fixes

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -10,7 +10,7 @@ for name, recipe in pairs(data.raw.recipe) do
             recipe.energy_required = 20
         elseif name == "zipir1-pyvoid" or name == "zipir1-pyvoid-hatchery" then
             recipe.enabled = false
-            recipe.category = "hpf"
+            recipe.categories = {"hpf"}
             recipe.flags = {}
             recipe.hidden = nil
         else

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -94,14 +94,14 @@ data.raw["assembling-machine"]["antelope-enclosure-mk01"].fluid_boxes_off_when_n
 data.raw["assembling-machine"]["antelope-enclosure-mk01"].fluid_boxes = {
     {
         production_type = "input",
-        pipe_picture = assembler2pipepictures(),
+        pipe_picture = require("__base__.prototypes.entity.assembler-pictures").assembler2pipepictures,
         pipe_covers = pipecoverspictures(),
         volume = 1000,
         pipe_connections = {{flow_direction = "input", position = {-8, 0}, direction = defines.direction.west}}
     },
     {
         production_type = "input",
-        pipe_picture = assembler2pipepictures(),
+        pipe_picture = require("__base__.prototypes.entity.assembler-pictures").assembler2pipepictures,
         pipe_covers = pipecoverspictures(),
         volume = 1000,
         pipe_connections = {{flow_direction = "input", position = {8, 0}, direction = defines.direction.east}}

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name": "pyhardmode",
   "version": "1.3.37",
-  "factorio_version": "2.0",
+  "factorio_version": "2.1",
   "title": "Pyanodons Hard Mode",
   "author": "notnotmelon",
   "contact": "https://discord.gg/SBHM3h5Utj",
@@ -9,8 +9,8 @@
   "description": "Contains a few tiny changes to Pyanodons mods...",
   "dependencies": [
     "base >= 2.0.12",
-    "pyalternativeenergy >= 3.0.0",
-    "? enable-all-feature-flags",
+    "pyalternativeenergy >= 3.2.0",
+    "+ enable-all-feature-flags",
     "? aai-loaders >= 0.2.3",
     "? PyBlock"
   ],

--- a/prototypes/macguffin.lua
+++ b/prototypes/macguffin.lua
@@ -18,7 +18,7 @@ ITEM {
 RECIPE {
     type = "recipe",
     name = "macguffin",
-    category = "antelope",
+    categories = {"antelope"},
     enabled = false,
     energy_required = 60,
     ingredients = {
@@ -50,9 +50,9 @@ RECIPE {
         {type = "item",  name = "pheromones",            amount = 1},
     },
     results = {
-        {type = "item", name = "macguffin",        amount = 1, probability = 0.1},
-        {type = "item", name = "caged-antelope",   amount = 1, probability = 0.5},
-        {type = "item", name = "yag-laser-module", amount = 1, probability = 0.9},
+        {type = "item", name = "macguffin",        amount = 1, independent_probability = 0.1},
+        {type = "item", name = "caged-antelope",   amount = 1, independent_probability = 0.5},
+        {type = "item", name = "yag-laser-module", amount = 1, independent_probability = 0.9},
     },
     main_product = "macguffin",
 }:add_unlock("space-science-pack")
@@ -72,7 +72,7 @@ data.raw.recipe["space-science-pack"].results = {{name = "quantum-simulation-dat
 RECIPE {
     name = "space-science-pack-real",
     type = "recipe",
-    category = "quantum",
+    categories = {"quantum"},
     enabled = false,
     energy_required = 600,
     ingredients = {
@@ -160,5 +160,5 @@ RECIPE {
     results = {
         {type = "item", name = "sweater", amount = 1},
     },
-    category = "quantum"
+    categories = {"quantum"}
 }:add_unlock("sweater")

--- a/prototypes/oil-boiler.lua
+++ b/prototypes/oil-boiler.lua
@@ -23,7 +23,7 @@ RECIPE {
         {type = "fluid", name = "steam", amount = 300, temperature = 250},
         {type = "fluid", name = "flue-gas", amount = 60}
     },
-    category = "oil-boiler-mk01",
+    categories = {"oil-boiler-mk01"},
     main_product = "steam"
 }
 

--- a/prototypes/recycling-recipes.lua
+++ b/prototypes/recycling-recipes.lua
@@ -4,7 +4,7 @@ if mods.PyBlock then
     RECIPE {
         type = "recipe",
         name = "muddy-sludge-void",
-        category = "washer",
+        categories = {"washer"},
         enabled = true,
         energy_required = 4,
         ingredients = {
@@ -20,7 +20,7 @@ else
     RECIPE {
         type = "recipe",
         name = "muddy-sludge-void-electrolyzer",
-        category = "electrolyzer",
+        categories = {"electrolyzer"},
         enabled = false,
         energy_required = 3,
         ingredients = {
@@ -40,7 +40,7 @@ end
 RECIPE {
     type = "recipe",
     name = "yaedols-spores-to-oxygen",
-    category = "hpf",
+    categories = {"hpf"},
     enabled = false,
     energy_required = 4,
     ingredients = {
@@ -58,7 +58,7 @@ local fluegas_to_ash = table.deepcopy(data.raw.recipe["fluegas-filtration"])
 data.raw.recipe["fluegas-filtration"].results = {}
 data.raw.recipe["fluegas-filtration"].energy_required = 2
 fluegas_to_ash.name = "fluegas-to-ash"
-fluegas_to_ash.category = "quenching-tower"
+fluegas_to_ash.categories = {"quenching-tower"}
 data:extend {fluegas_to_ash}
 RECIPE("fluegas-to-ash"):add_unlock("tar-processing")
 

--- a/prototypes/residual-gas.lua
+++ b/prototypes/residual-gas.lua
@@ -1,7 +1,7 @@
 RECIPE {
     type = "recipe",
     name = "residual-gas-to-gasoline",
-    category = "gas-refinery",
+    categories = {"gas-refinery"},
     enabled = false,
     energy_required = 10,
     ingredients = {
@@ -17,7 +17,7 @@ RECIPE {
 RECIPE {
     type = "recipe",
     name = "residual-gas-to-syngas",
-    category = "gas-refinery",
+    categories = {"gas-refinery"},
     enabled = false,
     energy_required = 10,
     ingredients = {
@@ -33,7 +33,7 @@ RECIPE {
 RECIPE {
     type = "recipe",
     name = "residual-gas-to-olefins",
-    category = "gas-refinery",
+    categories = {"gas-refinery"},
     enabled = false,
     energy_required = 10,
     ingredients = {


### PR DESCRIPTION
I'm not super experience with factorio dev, so if any of this is wrong, please tell me.

Update Factorio and PyAE versions
Change enable-all-feature-flags to the new 'recommended' dependency type
Recipe category and additional-categories are now flattened to 'categories'

The file in __base__ containing the assembler2pipepictures function seems to be gone in my steam install, despite existing in https://github.com/wube/factorio-data/blob/2.1.9/base/prototypes/entity/assemblerpipes.lua. This is the change I understand the least.

